### PR TITLE
Feature/measurement flow

### DIFF
--- a/src/services/measurement_service.py
+++ b/src/services/measurement_service.py
@@ -1,0 +1,7 @@
+from socketio import AsyncServer
+
+from sio.models import Lobby
+
+
+def measurement_controller(sio: AsyncServer, lobby: Lobby):
+    pass

--- a/src/services/measurement_service.py
+++ b/src/services/measurement_service.py
@@ -6,7 +6,7 @@ from typing import List, Dict
 from sio.models import Lobby, RecordData
 
 lobbies: Dict[str, Lobby] = {}
-measurement_tasks: dict[str, asyncio.Task] = {}
+measurement_tasks: dict[str, asyncio.Task] = {} # type: ignore
 measurement_queues: dict[str, asyncio.Queue[RecordData]] = {}
 
 logger = logging.getLogger(__name__)

--- a/src/services/measurement_service.py
+++ b/src/services/measurement_service.py
@@ -1,13 +1,14 @@
 import asyncio
 
 from socketio import AsyncServer
-from typing import List
+from typing import List, Dict
 from sio.models import Lobby, RecordData
 
+lobbies: Dict[str, Lobby] = {}
 measurement_tasks: dict[str, asyncio.Task] = {}
-measurement_queues: dict[str, asyncio.Queue] = {}
+measurement_queues: dict[str, asyncio.Queue[RecordData]] = {}
 
-async def measurement_controller(sio: AsyncServer, lobby: Lobby):
+async def measurement_controller(sio: AsyncServer, lobby: Lobby) -> None:
     await sio.emit("start_measurement", {}, to=lobby.lobby_id)
     measurement_queues[lobby.lobby_id] = asyncio.Queue()
 

--- a/src/services/measurement_service.py
+++ b/src/services/measurement_service.py
@@ -1,7 +1,31 @@
+import asyncio
+
 from socketio import AsyncServer
+from typing import List
+from sio.models import Lobby, RecordData
 
-from sio.models import Lobby
+measurement_tasks: dict[str, asyncio.Task] = {}
+measurement_queues: dict[str, asyncio.Queue] = {}
 
+async def measurement_controller(sio: AsyncServer, lobby: Lobby):
+    await sio.emit("start_measurement", {}, to=lobby.lobby_id)
+    measurement_queues[lobby.lobby_id] = asyncio.Queue()
 
-def measurement_controller(sio: AsyncServer, lobby: Lobby):
-    pass
+    await asyncio.sleep(1)
+
+    for speaker in lobby.speakers:
+        await sio.emit("play_sound", {}, to=speaker.sid)
+        await asyncio.sleep(0.5)
+
+    await sio.emit("end_measurement", {}, to=lobby.lobby_id)
+
+    record_data: List[RecordData] = []
+
+    while len(record_data) < len(measurement_queues):
+        data = await measurement_queues[lobby.lobby_id].get()
+        record_data.append(data)
+
+    # TODO do calculations
+
+    await asyncio.sleep(2)
+    await sio.emit("results", {}, lobby.lobby_id)

--- a/src/sio/events/lobby_events.py
+++ b/src/sio/events/lobby_events.py
@@ -3,7 +3,7 @@ import uuid
 
 from pydantic import BaseModel, ValidationError
 from socketio import AsyncServer
-from typing import Dict, List, cast
+from typing import cast
 
 from services.measurement_service import lobbies, measurement_tasks
 from sio.models import Lobby, LobbyClient, SocketSession

--- a/src/sio/events/lobby_events.py
+++ b/src/sio/events/lobby_events.py
@@ -4,24 +4,10 @@ from pydantic import BaseModel
 from socketio import AsyncServer
 from typing import Dict, List, cast
 
+from sio.models import Lobby, LobbyClient, SocketSession, lobbies
+
 
 def register_lobby_events(sio: AsyncServer) -> None:
-
-    class LobbyClient(BaseModel):
-        sid: str
-        index: int
-
-    class Lobby(BaseModel):
-        host: str
-        lobby_id: str
-        microphones: List[LobbyClient]
-        speakers: List[LobbyClient]
-
-    class SocketSession(BaseModel):
-        lobby: str
-        isHost: bool
-
-    lobbies: Dict[str, Lobby] = {}
 
     @sio.event # type: ignore
     def create_lobby(sid: str, _: None) -> None:

--- a/src/sio/events/lobby_events.py
+++ b/src/sio/events/lobby_events.py
@@ -1,12 +1,14 @@
+import logging
 import uuid
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from socketio import AsyncServer
 from typing import Dict, List, cast
 
-from services.measurement_service import lobbies
+from services.measurement_service import lobbies, measurement_tasks
 from sio.models import Lobby, LobbyClient, SocketSession
 
+logger = logging.getLogger(__name__)
 
 def register_lobby_events(sio: AsyncServer) -> None:
 
@@ -20,38 +22,51 @@ def register_lobby_events(sio: AsyncServer) -> None:
         await sio.emit("create_lobby_res", {"lobbyId": lobby_id}, to=lobby_id)
 
     class JoinEventData(BaseModel):
-        lobby_id: str
+        lobbyId: str
 
     @sio.event # type: ignore
     async def join_lobby(sid: str, data: JoinEventData) -> None:
-        if not data.lobby_id in lobbies:
-            await sio.emit("join_lobby_fail", {"reason": "Lobby not found"} ,to=sid)
 
-        await sio.save_session(sid, SocketSession(lobby=data.lobby_id, isHost=False))
-        if len(lobbies[data.lobby_id].speakers) < len(lobbies[data.lobby_id].microphones):
-            index = len(lobbies[data.lobby_id].speakers)
+        try:
+            data = JoinEventData.model_validate(data)
+        except ValidationError as e:
+            logger.error(e)
+            return
+
+        if not data.lobbyId in lobbies:
+            await sio.emit("join_lobby_fail", {"reason": "Lobby not found"} ,to=sid)
+            return
+
+        if data.lobbyId in measurement_tasks:
+            await sio.emit("join_lobby_fail", {"reason": "Lobby already running measurement"}, to=sid)
+            return
+
+        await sio.save_session(sid, SocketSession(lobby=data.lobbyId, isHost=False))
+        await sio.enter_room(sid, data.lobbyId)
+        if len(lobbies[data.lobbyId].speakers) < len(lobbies[data.lobbyId].microphones):
+            index = len(lobbies[data.lobbyId].speakers)
             client = LobbyClient(sid=sid, index=index)
-            lobbies[data.lobby_id].speakers.append(client)
+            lobbies[data.lobbyId].speakers.append(client)
             await sio.emit("join_lobby_success", {
                 "deviceType": "speaker",
                 "index": index
             },  to=sid)
         else:
-            index = len(lobbies[data.lobby_id].microphones)
+            index = len(lobbies[data.lobbyId].microphones)
             client = LobbyClient(sid=sid, index=index)
-            lobbies[data.lobby_id].microphones.append(client)
+            lobbies[data.lobbyId].microphones.append(client)
             await sio.emit("join_lobby_success", {
                 "deviceType": "microphone",
                 "index": index,
             }, to=sid)
 
-        mics = list(map(lambda m: m.index, lobbies[data.lobby_id].microphones))
-        speakers = list(map(lambda s: s.index, lobbies[data.lobby_id].speakers))
+        mics = list(map(lambda m: m.index, lobbies[data.lobbyId].microphones))
+        speakers = list(map(lambda s: s.index, lobbies[data.lobbyId].speakers))
 
         await sio.emit("device_choices", {
             "microphones": mics,
             "speakers": speakers,
-        }, to=data.lobby_id)
+        }, to=data.lobbyId)
 
 
 
@@ -61,7 +76,21 @@ def register_lobby_events(sio: AsyncServer) -> None:
 
     @sio.event # type: ignore
     async def chose_device_type(sid: str, data: ChoseDeviceTypeEventData) -> None:
-        session = cast(SocketSession, sio.get_session(sid))
+        try:
+            data = ChoseDeviceTypeEventData.model_validate(data)
+        except ValidationError as e:
+            logger.error(e)
+            return
+
+        session = cast(SocketSession, await sio.get_session(sid))
+
+        if not hasattr(session, "lobbyId"):
+            return
+
+        if session.lobby in measurement_tasks:
+            await sio.emit("cancel_measurement", {"reason": "Lobby already running measurement"}, to=sid)
+            return
+
         lobby = lobbies[session.lobby]
         lobby.microphones = list(filter(lambda m: m.sid != sid, lobby.microphones))
         lobby.speakers = list(filter(lambda s: s.sid != sid, lobby.speakers))

--- a/src/sio/events/lobby_events.py
+++ b/src/sio/events/lobby_events.py
@@ -1,18 +1,70 @@
+import uuid
+
 from pydantic import BaseModel
 from socketio import AsyncServer
+from typing import Dict, List, Iterable
 
 
 def register_lobby_events(sio: AsyncServer) -> None:
+
+    class LobbyClient(BaseModel):
+        sid: str
+        index: int
+
+    class Lobby(BaseModel):
+        host: str
+        lobby_id: str
+        microphones: List[LobbyClient]
+        speakers: List[LobbyClient]
+
+    class SocketSession(BaseModel):
+        lobby: str
+        isHost: bool
+
+    lobbys: Dict[str, Lobby] = {}
+
     @sio.event # type: ignore
     def create_lobby(sid: str, data: None) -> None:
-        pass
+        lobby_id = str(uuid.uuid4())
+        client = LobbyClient(sid=sid, index=0)
+        lobbys[lobby_id] = Lobby(host=sid, lobby_id=lobby_id, microphones=[client], speakers=[])
+        sio.save_session(sid, SocketSession(lobby=lobby_id, isHost=True))
+        sio.enter_room(sid, lobby_id)
+        sio.emit("create_lobby_res", {"lobbyId": lobby_id}, to=lobby_id)
 
     class JoinEventData(BaseModel):
-        lobbyId: str
+        lobby_id: str
 
     @sio.event # type: ignore
     def join_lobby(sid: str, data: JoinEventData) -> None:
-        pass
+        if not data.lobby_id in lobbys:
+            sio.emit("join_lobby_fail", {"reason": "Lobby not found"} ,to=sid)
+
+        sio.save_session(sid, SocketSession(lobby=data.lobby_id, isHost=False))
+        if len(lobbys[data.lobby_id].speakers) < len(lobbys[data.lobby_id].microphones):
+            index = len(lobbys[data.lobby_id].speakers)
+            client = LobbyClient(sid=sid, index=index)
+            lobbys[data.lobby_id].speakers.append(client)
+            sio.emit("join_lobby_success", {
+                "deviceType": "speaker",
+                "index": index,
+                "microphoneCount": len(lobbys[data.lobby_id].microphones),
+                "speakerCount": len(lobbys[data.lobby_id].speakers),},  to=sid)
+        else:
+            index = len(lobbys[data.lobby_id].microphones)
+            client = LobbyClient(sid=sid, index=index)
+            lobbys[data.lobby_id].microphones.append(client)
+            sio.emit("join_lobby_success", {
+                "deviceType": "microphone",
+                "index": index,
+                "microphoneCount": len(lobbys[data.lobby_id].microphones),
+                "speakerCount": len(lobbys[data.lobby_id].speakers), }, to=sid)
+
+        sio.emit("user_joined_lobby", {
+            "microphoneCount": len(lobbys[data.lobby_id].microphones),
+            "speakerCount": len(lobbys[data.lobby_id].speakers)}, to=data.lobby_id)
+
+
 
     class ChoseDeviceTypeEventData(BaseModel):
         device: str
@@ -21,7 +73,5 @@ def register_lobby_events(sio: AsyncServer) -> None:
     @sio.event # type: ignore
     def chose_device_type(sid: str, data: ChoseDeviceTypeEventData) -> None:
         pass
-
-
 
 

--- a/src/sio/events/lobby_events.py
+++ b/src/sio/events/lobby_events.py
@@ -4,7 +4,8 @@ from pydantic import BaseModel
 from socketio import AsyncServer
 from typing import Dict, List, cast
 
-from sio.models import Lobby, LobbyClient, SocketSession, lobbies
+from services.measurement_service import lobbies
+from sio.models import Lobby, LobbyClient, SocketSession
 
 
 def register_lobby_events(sio: AsyncServer) -> None:
@@ -33,9 +34,7 @@ def register_lobby_events(sio: AsyncServer) -> None:
             lobbies[data.lobby_id].speakers.append(client)
             await sio.emit("join_lobby_success", {
                 "deviceType": "speaker",
-                "index": index,
-                "microphoneCount": len(lobbies[data.lobby_id].microphones),
-                "speakerCount": len(lobbies[data.lobby_id].speakers),
+                "index": index
             },  to=sid)
         else:
             index = len(lobbies[data.lobby_id].microphones)

--- a/src/sio/events/measurement_events.py
+++ b/src/sio/events/measurement_events.py
@@ -1,11 +1,30 @@
 from pydantic import BaseModel
 from socketio import AsyncServer
+from typing import cast
+import asyncio
+
+from services.measurement_service import measurement_controller
+from sio.models import SocketSession, lobbies
 
 
 def register_measurement_events(sio: AsyncServer) -> None:
     @sio.event # type: ignore
     def start_measurement(sid: str, data: None) -> None:
-        pass
+        session = cast(SocketSession, sio.get_session(sid))
+        if not session.isHost:
+            return
+
+        if len(lobbies[session.lobby].speakers) == 0:
+            sio.emit("start_measurement_fail", {"reason": "Not enough speakers!"})
+        elif len(lobbies[session.lobby].microphones) == 0:
+            sio.emit("start_measurement_fail", {"reason": "Not enough speakers!"})
+
+        asyncio.create_task(measurement_controller())
+
+
+
+
+
 
     class SendRecordEventData(BaseModel):
         recording: str

--- a/src/sio/events/measurement_events.py
+++ b/src/sio/events/measurement_events.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel
+import logging
+
+from pydantic import BaseModel, ValidationError
 from socketio import AsyncServer
 from typing import cast
 import asyncio
@@ -6,18 +8,28 @@ import asyncio
 from services.measurement_service import measurement_controller, lobbies, measurement_tasks, measurement_queues
 from sio.models import SocketSession, RecordData
 
+logger = logging.getLogger("sio")
 
 def register_measurement_events(sio: AsyncServer) -> None:
     @sio.event # type: ignore
     async def start_measurement(sid: str, _: None) -> None:
-        session = cast(SocketSession, sio.get_session(sid))
-        if not session.isHost:
+        session = cast(SocketSession, await sio.get_session(sid))
+        if not hasattr(session, "isHost") or not session.isHost or session.isHost in measurement_tasks.keys():
+            return
+
+        mic_indices = {c.index for c in lobbies[session.lobby].microphones}
+        speaker_indices = {c.index for c in lobbies[session.lobby].speakers}
+
+        if not set(mic_indices) == (set(range(len(mic_indices)))) or not set(speaker_indices) == (set(range(len(speaker_indices)))):
+            await sio.emit("start_measurement_fail", {"reason": "Some indices are not filled."})
             return
 
         if len(lobbies[session.lobby].speakers) == 0:
             await sio.emit("start_measurement_fail", {"reason": "Not enough speakers!"})
+            return
         elif len(lobbies[session.lobby].microphones) == 0:
             await sio.emit("start_measurement_fail", {"reason": "Not enough microphones!"})
+            return
 
         task = asyncio.create_task(measurement_controller(sio, lobby=lobbies[session.lobby]))
         measurement_tasks[session.lobby] = task
@@ -29,5 +41,12 @@ def register_measurement_events(sio: AsyncServer) -> None:
 
     @sio.event # type: ignore
     async def send_record_data(sid: str, data: SendRecordEventData) -> None:
-        session = cast(SocketSession, sio.get_session(sid))
+        try:
+            data = SendRecordEventData.model_validate(data)
+        except ValidationError as e:
+            logger.error(e)
+            return
+
+        session = cast(SocketSession, await sio.get_session(sid))
+        logger.warning(f"Sending record data: {data}")
         await measurement_queues[session.lobby].put(RecordData(sid=sid, recording=data.recording))

--- a/src/sio/events/measurement_events.py
+++ b/src/sio/events/measurement_events.py
@@ -14,7 +14,7 @@ def register_measurement_events(sio: AsyncServer) -> None:
     @sio.event # type: ignore
     async def start_measurement(sid: str, _: None) -> None:
         session = cast(SocketSession, await sio.get_session(sid))
-        if not hasattr(session, "isHost") or not session.isHost or session.isHost in measurement_tasks.keys():
+        if not hasattr(session, "isHost") or not session.isHost or session.lobby in measurement_tasks.keys():
             return
 
         mic_indices = {c.index for c in lobbies[session.lobby].microphones}

--- a/src/sio/events/measurement_events.py
+++ b/src/sio/events/measurement_events.py
@@ -3,11 +3,11 @@ from socketio import AsyncServer
 from typing import cast
 import asyncio
 
-from services.measurement_service import measurement_controller, measurement_tasks, measurement_queues
-from sio.models import SocketSession, lobbies
+from services.measurement_service import measurement_controller, lobbies, measurement_tasks, measurement_queues
+from sio.models import SocketSession, RecordData
 
 
-async def register_measurement_events(sio: AsyncServer) -> None:
+def register_measurement_events(sio: AsyncServer) -> None:
     @sio.event # type: ignore
     async def start_measurement(sid: str, _: None) -> None:
         session = cast(SocketSession, sio.get_session(sid))
@@ -30,4 +30,4 @@ async def register_measurement_events(sio: AsyncServer) -> None:
     @sio.event # type: ignore
     async def send_record_data(sid: str, data: SendRecordEventData) -> None:
         session = cast(SocketSession, sio.get_session(sid))
-        await measurement_queues[session.lobby].put({"sid": sid, "recording": data.recording})
+        await measurement_queues[session.lobby].put(RecordData(sid=sid, recording=data.recording))

--- a/src/sio/models.py
+++ b/src/sio/models.py
@@ -21,5 +21,3 @@ class SocketSession(BaseModel):
 class RecordData(BaseModel):
     sid: str
     recording: str
-
-lobbies: Dict[str, Lobby] = {}

--- a/src/sio/models.py
+++ b/src/sio/models.py
@@ -18,4 +18,8 @@ class SocketSession(BaseModel):
     lobby: str
     isHost: bool
 
+class RecordData(BaseModel):
+    sid: str
+    recording: str
+
 lobbies: Dict[str, Lobby] = {}

--- a/src/sio/models.py
+++ b/src/sio/models.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from typing import List, Dict
+
+
+class LobbyClient(BaseModel):
+    sid: str
+    index: int
+
+
+class Lobby(BaseModel):
+    host: str
+    lobby_id: str
+    microphones: List[LobbyClient]
+    speakers: List[LobbyClient]
+
+
+class SocketSession(BaseModel):
+    lobby: str
+    isHost: bool
+
+lobbies: Dict[str, Lobby] = {}

--- a/src/sio/socketio_server.py
+++ b/src/sio/socketio_server.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 import socketio
@@ -6,9 +5,9 @@ import socketio
 from services.measurement_service import measurement_tasks, lobbies, measurement_queues
 from .events.lobby_events import register_lobby_events
 from .events.measurement_events import register_measurement_events
-from typing import Dict, cast
+from typing import cast
 
-from .models import Lobby, RecordData, SocketSession
+from .models import SocketSession
 
 sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')
 app = socketio.ASGIApp(sio, static_files=None)

--- a/src/sio/socketio_server.py
+++ b/src/sio/socketio_server.py
@@ -1,17 +1,48 @@
+import asyncio
+
 import socketio
+
+from services.measurement_service import measurement_tasks, lobbies, measurement_queues
 from .events.lobby_events import register_lobby_events
 from .events.measurement_events import register_measurement_events
+from typing import Dict, cast
+
+from .models import Lobby, RecordData, SocketSession
 
 sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')
 app = socketio.ASGIApp(sio, static_files=None)
+
 
 @sio.event # type: ignore
 def connect(sid, environ) -> None:
     print('Client connected:', sid)
 
 @sio.event # type: ignore
-def disconnect(sid) -> None:
+async def disconnect(sid) -> None:
     print('Client disconnected:', sid)
+    session = cast(SocketSession, sio.get_session(sid))
+    if session and session.lobby:
+        if measurement_tasks[session.lobby]:
+            measurement_tasks[session.lobby].cancel()
+            measurement_tasks.pop(session.lobby)
+
+            await sio.emit("cancel_measurement", {"reason": "A client has disconnected"
+            }, to=session.lobby)
+            lobbies.pop(session.lobby)
+            measurement_queues.pop(session.lobby)
+
+        else:
+            lobby = lobbies[session.lobby]
+            lobby.microphones = list(filter(lambda m: m.sid != sid, lobby.microphones))
+            lobby.speakers = list(filter(lambda s: s.sid != sid, lobby.speakers))
+
+            mics = list(map(lambda m: m.index, lobby.microphones))
+            speakers = list(map(lambda s: s.index, lobby.speakers))
+
+            await sio.emit("device_choices", {
+                "microphones": mics,
+                "speakers": speakers,
+            }, to=lobby.lobby_id)
 
 @sio.event # type: ignore
 def message(sid, data) -> None:

--- a/src/sio/socketio_server.pyi
+++ b/src/sio/socketio_server.pyi
@@ -1,5 +1,8 @@
 # socketio.pyi
-from typing import TypeVar, Callable, ParamSpec, Any, Optional
+import asyncio
+from typing import TypeVar, Callable, ParamSpec, Any, Optional, Dict
+
+from sio.models import Lobby, RecordData
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -10,3 +13,7 @@ class AsyncServer:
     def emit(self, event: str, data: Any, room: Optional[str] = ...) -> None: ...
 
 sio_app: Any
+
+lobbies: Dict[str, Lobby]
+measurement_tasks: dict[str, asyncio.Task]
+measurement_queues: dict[str, asyncio.Queue[RecordData]]

--- a/src/sio/socketio_server.pyi
+++ b/src/sio/socketio_server.pyi
@@ -13,7 +13,3 @@ class AsyncServer:
     def emit(self, event: str, data: Any, room: Optional[str] = ...) -> None: ...
 
 sio_app: Any
-
-lobbies: Dict[str, Lobby]
-measurement_tasks: dict[str, asyncio.Task]
-measurement_queues: dict[str, asyncio.Queue[RecordData]]


### PR DESCRIPTION
closes #33 

Die serverseitige Logik des Measurement-Flows ist vollständig implementiert und getestet. Die Dokumentation dazu findet sich im Miroboard sowie im verlinkten [hier](https://github.com/sonalyze/aal-backend/issues/33#issuecomment-2956342519) Aktuell wird die Berechnung der Ergebnisse noch nicht durchgeführt, dafür werden aber Mock Daten bei "results" mitgegeben. 