### PR TITLE
Add user_id mapping to LobbyClient and connection flow

### DIFF
--- a/src/services/measurement_service.py
+++ b/src/services/measurement_service.py
@@ -8,6 +8,7 @@ from sio.models import Lobby, RecordData
 lobbies: Dict[str, Lobby] = {}
 measurement_tasks: dict[str, asyncio.Task] = {} # type: ignore
 measurement_queues: dict[str, asyncio.Queue[RecordData]] = {}
+id_map: dict[str, str] = {} # maps sid to user_id
 
 logger = logging.getLogger("uvicorn.info")
 

--- a/src/sio/models.py
+++ b/src/sio/models.py
@@ -1,10 +1,11 @@
 from pydantic import BaseModel
-from typing import List, Dict
+from typing import List
 
 
 class LobbyClient(BaseModel):
     sid: str
     index: int
+    user_id: str
 
 
 class Lobby(BaseModel):

--- a/src/sio/socketio_server.py
+++ b/src/sio/socketio_server.py
@@ -1,8 +1,9 @@
 import logging
 
 import socketio
+from bson import ObjectId
 
-from services.measurement_service import measurement_tasks, lobbies, measurement_queues
+from services.measurement_service import measurement_tasks, lobbies, measurement_queues, id_map
 from .events.lobby_events import register_lobby_events
 from .events.measurement_events import register_measurement_events
 from typing import cast
@@ -15,13 +16,27 @@ app = socketio.ASGIApp(sio, static_files=None)
 logger = logging.getLogger("uvicorn.info")
 
 @sio.event # type: ignore
-async def connect(sid, environ) -> None:
-    logger.info(f"Connected {sid}")
+async def connect(sid, environ, auth) -> None:
+    if not auth:
+        logger.info(f"Refused {sid} because of missing user_id")
+        await sio.disconnect(sid)
+        return
+
+    token = auth["token"]
+    if not ObjectId.is_valid(token):
+        logger.info(f"Refused {sid} because of invalid user_id")
+        await sio.disconnect(sid)
+        return
+    id_map[sid] = token
+    logger.info(f"Connected {sid} with user_id {token}")
 
 @sio.event # type: ignore
 async def disconnect(sid, reason) -> None:
     logger.info(f"Disconnected {sid}")
     session = cast(SocketSession, await sio.get_session(sid))
+    if sid in id_map:
+        del id_map[sid]
+
     if hasattr(session, 'lobby'):
         if session.lobby in measurement_tasks.keys():
             measurement_tasks[session.lobby].cancel()


### PR DESCRIPTION
Socket.IO clients are now authorized with their userToken, enabling us to save measurements for them in the future.